### PR TITLE
fix: update catalystcommunity dependency version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/brianvoe/gofakeit/v6 v6.21.0
-	github.com/catalystcommunity/app-utils-go v1.0.7
+	github.com/catalystcommunity/app-utils-go v1.0.9
 	github.com/cockroachdb/cockroach-go/v2 v2.3.3
 	github.com/dariubs/gorm-jsonb v0.1.5
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/brianvoe/gofakeit/v6 v6.21.0 h1:tNkm9yxEbpuPK8Bx39tT4sSc5i9SUGiciLdNix+VDQY=
 github.com/brianvoe/gofakeit/v6 v6.21.0/go.mod h1:Ow6qC71xtwm79anlwKRlWZW6zVq9D2XHE4QSSMP/rU8=
-github.com/catalystcommunity/app-utils-go v1.0.7 h1:oOJBcA8tbb4QjJ8J5MHilMcd1k3l1fz7kcBMONlZ104=
-github.com/catalystcommunity/app-utils-go v1.0.7/go.mod h1:zJwtRgtrC5qNCjiKY9N9vQqxruNyvZvG779aYlcHbcs=
+github.com/catalystcommunity/app-utils-go v1.0.9 h1:0WgpT1XMloyu0BYEwmF3h21LjX0zKZ1qZ9iDSPW6bys=
+github.com/catalystcommunity/app-utils-go v1.0.9/go.mod h1:6TUs51pXf4+24a5qPBAU/qlH738WrrQBa2JcVDSoot0=
 github.com/cockroachdb/cockroach-go/v2 v2.3.3 h1:fNmtG6XhoA1DhdDCIu66YyGSsNb1szj4CaAsbDxRmy4=
 github.com/cockroachdb/cockroach-go/v2 v2.3.3/go.mod h1:1wNJ45eSXW9AnOc3skntW9ZUZz6gxrQK3cOj3rK+BC8=
 github.com/dariubs/gorm-jsonb v0.1.5 h1:0sc6pBQ0V1i3MqIos3SiQjRxtzs3pTnAZaAtb+SFM20=


### PR DESCRIPTION
you're going to see a lot more of these from me.

there isn't a release that contains the new go.mod file changes from the org migration. this change should trigger a release that should fix that problem.

additionally, this change updates the only catalystcommunity dependency of this go project to prevent problems when importing the package from the new org url.